### PR TITLE
fix: Fix nfs-ganesha package FSAL library being overwritten

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+saunafs (4.7.0-3) stable; urgency=medium
+
+  * Fix missing Ganesha package
+
+ -- Saunafs Team <support@saunafs.com>  Mon, 10 Feb 2025 13:39:09 +0200
+
 saunafs (4.7.0-2) stable; urgency=medium
 
   * Add patch for LIMIT_GLIBC_MALLOC_ARENAS option

--- a/debian/saunafs-nfs-ganesha.install
+++ b/debian/saunafs-nfs-ganesha.install
@@ -1,1 +1,1 @@
-usr/lib/*/ganesha/libfsalsaunafs.so
+usr/lib/*/ganesha/libfsalsaunafs.so*

--- a/debian/saunafs-nfs-ganesha.links
+++ b/debian/saunafs-nfs-ganesha.links
@@ -1,3 +1,0 @@
-usr/lib/ganesha/libfsalsaunafs.so usr/lib/ganesha/libfsalsaunafs.so.4
-usr/lib/ganesha/libfsalsaunafs.so.4 usr/lib/ganesha/libfsalsaunafs.so.4.2.0
-usr/lib/ganesha/libfsalsaunafs.so usr/lib/x86_64-linux-gnu/ganesha/libfsalsaunafs.so


### PR DESCRIPTION
In 4.6.0-1, the installation of the FSAL was changed not to be hardcoded to /usr/lib/ganesha/, but instead to be /usr/lib/*/ganesha, where the * could be /usr/lib/x86_64-linux-gnu/ or simply /usr/lib/ganesha/, for example. However, a symlink in the .links file was linking /usr/lib/x86_64-linux-gnu/libfsalsaunafs.so incorrectly to /usr/lib/ganesha/libfsalsaunafs.so, causing it to be overwritten if it the libfsalsaunafs.so was installed in x86_64-linux-gnu.

This commit makes the FSAL packaging more aligned with Ubuntu and Debain, which is to copy all libfsalsaunafs.so files to the same wildcard path in .install, and removing the .links file.

An example of FSAL's building on Ubuntu can be found here: https://git.launchpad.net/ubuntu/+source/nfs-ganesha/tree/debian/nfs-ganesha-gpfs.install?h=applied/ubuntu/jammy