### PR TITLE
feat: Add timeout to chunkserver service files

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+saunafs (4.8.1-2) stable; urgency=medium
+
+  * Set chunkserver timeout to 1200
+
+ -- Saunafs Team <support@saunafs.com>  Wed, 29 Apr 2025 15:32:33 +0200
+
 saunafs (4.8.1-1) stable; urgency=medium
 
   * Update SaunaFS version

--- a/debian/saunafs-chunkserver.service
+++ b/debian/saunafs-chunkserver.service
@@ -5,6 +5,7 @@ After=network-online.target network.target
 
 [Service]
 Type=forking
+TimeoutSec=0
 ExecStart=/usr/sbin/sfschunkserver start
 ExecStop=/usr/sbin/sfschunkserver stop
 ExecReload=/usr/sbin/sfschunkserver reload


### PR DESCRIPTION
Sometimes the chunkserver can take a long time to start, especially on
larger setups. This commit adds the timeout option found in master
service file to prevent any early killing of the chunkserver.