### PR TITLE
Fix service files

### DIFF
--- a/debian/saunafs-cgiserv.default
+++ b/debian/saunafs-cgiserv.default
@@ -4,11 +4,11 @@
 # This is a POSIX shell fragment
 #
 
-## user to run daemon as (default: nobody)
-# SAUNAFSCGISERV_USER=nobody
+## user to run daemon as (default: saunafs)
+# SAUNAFSCGISERV_USER=saunafs
 
-## group to run daemon as (default: nogroup)
-# SAUNAFSCGISERV_GROUP=nogroup
+## group to run daemon as (default: saunafs)
+# SAUNAFSCGISERV_GROUP=saunafs
 
 ## local address to listen on (default: any)
 # BIND_HOST=localhost

--- a/debian/saunafs-cgiserv.init
+++ b/debian/saunafs-cgiserv.init
@@ -16,8 +16,8 @@
 NAME=saunafs-cgiserv
 EXEC=/usr/bin/python3
 DAEMON=/usr/sbin/saunafs-cgiserver
-SAUNAFSCGISERV_USER=nobody
-SAUNAFSCGISERV_GROUP=nogroup
+SAUNAFSCGISERV_USER=saunafs
+SAUNAFSCGISERV_GROUP=saunafs
 BIND_HOST=0.0.0.0
 BIND_PORT=9425
 ROOT_PATH=/usr/share/sfscgi

--- a/debian/saunafs-cgiserv.service
+++ b/debian/saunafs-cgiserv.service
@@ -10,7 +10,7 @@ Environment=ROOT_PATH=/usr/share/sfscgi
 EnvironmentFile=-/etc/default/%p
 ExecStart=/usr/sbin/saunafs-cgiserver -H ${BIND_HOST} -P ${BIND_PORT} -R ${ROOT_PATH}
 Restart=on-abort
-User=nobody
+User=saunafs
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
- fix: Change user for saunafs-cgiserv service

The generic nobody user can lead to conflicts or security breaches. This ensure the service is run with the proper saunafs user.