### PR TITLE
refactor: Remove deprecated sfscgiserv

### DIFF
--- a/debian/saunafs-cgiserv.install
+++ b/debian/saunafs-cgiserv.install
@@ -1,2 +1,1 @@
 usr/sbin/saunafs-cgiserver
-usr/sbin/sfscgiserv


### PR DESCRIPTION
The old sfscgiserv python script had been deprecated in favor of saunafs-cgiserver. This commit removes the deprecated files.

BREAKING CHANGE: Old deployments relying on the old sfscgiserv would stop working and require update to use saunafs-cgiserver.