### PR TITLE
fix(uRaft): Prevent electors from starting MDS

### DIFF
--- a/debian/saunafs-ha-master.service
+++ b/debian/saunafs-ha-master.service
@@ -6,9 +6,9 @@ PartOf=saunafs-uraft.service
 [Service]
 Type=forking
 TimeoutSec=0
-ExecStart=/usr/sbin/sfsmaster -o ha-cluster-managed -o initial-personality=shadow start
-ExecStop=/usr/sbin/sfsmaster -o ha-cluster-managed -o initial-personality=shadow stop
-ExecReload=/usr/sbin/sfsmaster -o ha-cluster-managed -o initial-personality=shadow reload
+ExecStart=/usr/sbin/saunafs-uraft-helper start-saunafs-ha-master
+ExecStop=/usr/sbin/saunafs-uraft-helper stop-saunafs-ha-master
+ExecReload=/usr/sbin/saunafs-uraft-helper reload-saunafs-ha-master
 Restart=no
 
 [Install]


### PR DESCRIPTION
This PR is the complement of SaunaFS [#423](https://github.com/leil-io/saunafs/pull/423) and should be merged after SaunaFS #423 because it relies on `saunafs-ha-master` script to be deployed as part of the SaunaFS installation.