### PR TITLE
fix: Revert sysvinit removal

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 saunafs (5.2.0~rc1-1) stable; urgency=medium
 
   * Update SaunaFS version
+  * Revert the sysvinit removal
 
  -- Saunafs Team <support@saunafs.com>  Mon, 01 Sep 2025 17:06:29 +0000
 

--- a/debian/control
+++ b/debian/control
@@ -2,44 +2,55 @@ Source: saunafs
 Section: admin
 Priority: extra
 Maintainer: SaunaFS <contact@saunafs.com>
+Build-Depends: asciidoc (>= 8.6.6),
 # Probably half the packages are not needed, but we need a thorough review of
 # this
-Build-Depends: asciidoc (>= 8.6.6),
-	       debhelper (>= 13),
-	       cmake (>= 2.8),
-	       libfuse3-dev,
-	       pkg-config,
-	       zlib1g-dev,
-	       libspdlog-dev,
-	       libfmt-dev,
-	       libjudy-dev,
-	       libboost-system-dev,
-	       libboost-program-options-dev,
-	       libboost-filesystem-dev,
-	       python3,
-	       libyaml-cpp-dev,
+               debhelper (>= 9),
+               cmake (>= 2.8),
+               libfuse3-dev,
+               pkg-config,
+               zlib1g-dev,
+               libspdlog-dev,
+               libfmt-dev,
+               libjudy-dev,
+               libboost-system-dev,
+               libboost-program-options-dev,
+               libboost-filesystem-dev,
+               python3,
+               libyaml-cpp-dev,
 	       liburcu-dev,
 	       libblkid-dev,
+	       libboost-filesystem-dev,
 	       libboost-iostreams-dev,
+	       libboost-program-options-dev,
+	       libboost-system-dev,
 	       libcrcutil-dev,
 	       libdb-dev,
+	       libfmt-dev,
+	       libfuse3-dev,
 	       libgoogle-perftools-dev,
 	       libgtest-dev,
 	       libisal-dev,
 	       libpam0g-dev,
+	       libspdlog-dev,
 	       libsystemd-dev,
 	       libthrift-dev,
 	       libtirpc-dev,
+	       liburcu-dev,
+	       libyaml-cpp-dev,
 	       uuid-dev,
+	       zlib1g-dev,
+	       libacl1-dev,
 	       libcap-dev,
 	       libdbus-1-dev,
 	       libacl1-dev,
+	       libcap-dev,
+	       libdbus-1-dev,
 	       libjemalloc-dev,
 	       libkrb5-dev,
 	       libnfsidmap-dev,
 	       libnsl-dev,
 	       libsqlite3-dev,
-	       systemd
 Rules-Requires-Root: no
 Standards-Version: 3.9.3
 Homepage: https://saunafs.org/
@@ -64,19 +75,19 @@ Description: SaunaFS common files
 
 Package: saunafs-master
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, saunafs-common, systemd
+Depends: ${shlibs:Depends}, ${misc:Depends}, saunafs-common
 Description: SaunaFS master server
  SaunaFS master (metadata) server.
 
 Package: saunafs-metalogger
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, saunafs-common, systemd
+Depends: ${shlibs:Depends}, ${misc:Depends}, saunafs-common
 Description: SaunaFS metalogger server
  SaunaFS metalogger (metadata replication) server.
 
 Package: saunafs-chunkserver
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, saunafs-common, systemd
+Depends: ${shlibs:Depends}, ${misc:Depends}, saunafs-common
 Description: SaunaFS data server
  SaunaFS data server.
 
@@ -114,7 +125,7 @@ Description: SaunaFS CGI Monitor
 Package: saunafs-cgiserv
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}, saunafs-cgi,
-         python3, systemd
+         python3
 Description: Simple CGI-capable HTTP server to run SaunaFS CGI Monitor
  Simple CGI-capable HTTP server to run SaunaFS CGI Monitor.
 
@@ -124,9 +135,7 @@ Depends: saunafs-master,
          saunafs-adm,
          iputils-arping,
          sudo,
-         systemd,
          ${shlibs:Depends},
-         ${misc:Depends}
 Description: SaunaFS cluster management tool
  SaunaFS is a distributed filesystem.
  .

--- a/debian/rules
+++ b/debian/rules
@@ -8,7 +8,8 @@ export VERSION_SUFFIX ?= -unofficial
 export GIT_COMMIT ?= Unknown
 export GIT_BRANCH ?= Unknown
 
-.PHONY: override_dh_strip override_dh_auto_configure override_dh_installsystemd
+.PHONY: override_dh_strip override_dh_auto_configure override_dh_installsystemd override_dh_installinit
+
 
 override_dh_auto_configure:
 	dh_auto_configure --                               \
@@ -35,8 +36,13 @@ override_dh_auto_configure:
 override_dh_strip:
 	dh_strip --dbg-package=saunafs-dbg
 
+override_dh_installinit:
+	dh_installinit --no-start
+	dh_installinit --no-start -psaunafs-uraft --name=saunafs-ha-master
+
 override_dh_installsystemd:
 	dh_installsystemd --no-enable --no-start
+	dh_installsystemd --no-enable --no-start -psaunafs-uraft --name=saunafs-ha-master
 
 %:
 	dh $@ --buildsystem=cmake

--- a/debian/rules-nosystemd
+++ b/debian/rules-nosystemd
@@ -1,0 +1,16 @@
+#!/usr/bin/make -f
+# -*- makefile -*-
+
+# Uncomment this to turn on verbose mode.
+#export DH_VERBOSE=1
+
+.PHONY: override_dh_strip override_dh_auto_configure
+
+override_dh_auto_configure:
+	./configure --with-doc
+
+override_dh_strip:
+	dh_strip --dbg-package=saunafs-dbg
+
+%:
+	dh $@

--- a/debian/saunafs-cgiserv.default
+++ b/debian/saunafs-cgiserv.default
@@ -1,0 +1,20 @@
+# Defaults for saunafs-cgiserv
+# saunafs-cgiserver(8)
+#
+# This is a POSIX shell fragment
+#
+
+## user to run daemon as (default: saunafs)
+# SAUNAFSCGISERV_USER=saunafs
+
+## group to run daemon as (default: saunafs)
+# SAUNAFSCGISERV_GROUP=saunafs
+
+## local address to listen on (default: any)
+# BIND_HOST=localhost
+
+## port to listen on (default: 9425)
+# BIND_PORT=9425
+
+## local path to use as HTTP document root (default: /usr/share/sfscgi)
+# ROOT_PATH=/usr/share/sfscgi

--- a/debian/saunafs-cgiserv.init
+++ b/debian/saunafs-cgiserv.init
@@ -1,0 +1,79 @@
+#!/bin/sh
+#
+### BEGIN INIT INFO
+# Provides:            saunafs-cgiserv
+# Required-Start:      $local_fs $network $syslog $remote_fs
+# Required-Stop:       $local_fs $syslog $remote_fs
+# Should-Start:        $syslog
+# Should-Stop:         $network $syslog
+# Default-Start:       2 3 4 5
+# Default-Stop:        0 1 6
+# Short-Description:   Start up the saunafs-cgiserv server daemon
+# Description:         SaunaFS is a distributed, scalable, fault-tolerant and highly available file system.
+#                      This service starts up the SaunaFS cgiserv server daemon.
+### END INIT INFO
+
+NAME=saunafs-cgiserv
+EXEC=/usr/bin/python3
+DAEMON=/usr/sbin/saunafs-cgiserver
+SAUNAFSCGISERV_USER=saunafs
+SAUNAFSCGISERV_GROUP=saunafs
+BIND_HOST=0.0.0.0
+BIND_PORT=9425
+ROOT_PATH=/usr/share/sfscgi
+
+# Exit if executable is not installed
+[ -x $DAEMON ] || exit 0
+
+# Read configuration variable file if it is present
+DEFAULTS_FILE=/etc/default/${NAME}
+[ -r "$DEFAULTS_FILE" ] && . $DEFAULTS_FILE
+
+PIDF=/var/run/${NAME}.pid
+RETRY=TERM/30/KILL/5
+
+# Load the VERBOSE setting and other rcS variables
+[ -f /etc/default/rcS ] && . /etc/default/rcS
+
+# define LSB log_* functions.
+. /lib/lsb/init-functions
+
+case "$1" in
+    start)
+        if $0 status >>/dev/null; then
+            log_action_msg "$NAME is already running"
+            exit 0
+        fi
+        log_action_begin_msg "$NAME starting"
+        if R=$(start-stop-daemon --start --exec ${EXEC} --oknodo --pidfile ${PIDF} --make-pidfile \
+            --background --chuid ${SAUNAFSCGISERV_USER}:${SAUNAFSCGISERV_GROUP} \
+            -- $DAEMON -H ${BIND_HOST} -P ${BIND_PORT} -R ${ROOT_PATH} 2>&1);
+        then
+            log_action_end_msg 0 "$R"
+        else
+            log_action_end_msg 1 "$R"
+        fi
+    ;;
+    stop)
+        log_action_begin_msg "$NAME stopping"
+        if R=$(start-stop-daemon --stop --exec $EXEC --pidfile $PIDF --retry=$RETRY --quiet);
+        then
+            log_action_end_msg 0 "$R"
+        else
+            log_action_end_msg 1 "not running"
+        fi
+        rm -f "$PIDF"
+    ;;
+    force-reload|restart)
+        $0 stop
+        $0 start
+    ;;
+    status)
+        ## return status 0 if process is running.
+        status_of_proc -p "$PIDF" "$DAEMON" "$NAME"
+    ;;
+    *)
+        N=/etc/init.d/$NAME
+        echo "Usage: $N {start|stop|restart|force-reload|status}" >&2
+    ;;
+esac

--- a/debian/saunafs-cgiserv.service
+++ b/debian/saunafs-cgiserv.service
@@ -4,14 +4,13 @@ Documentation=man:saunafs-cgiserver
 After=network-online.target network.target
 
 [Service]
-User=saunafs
-Group=saunafs
 Environment=BIND_HOST=0.0.0.0
 Environment=BIND_PORT=9425
 Environment=ROOT_PATH=/usr/share/sfscgi
 EnvironmentFile=-/etc/default/%p
 ExecStart=/usr/sbin/saunafs-cgiserver -H ${BIND_HOST} -P ${BIND_PORT} -R ${ROOT_PATH}
 Restart=on-abort
+User=saunafs
 
 [Install]
 WantedBy=multi-user.target

--- a/debian/saunafs-chunkserver.default
+++ b/debian/saunafs-chunkserver.default
@@ -1,0 +1,8 @@
+# /etc/default/saunafs-chunkserver
+
+# Start saunafs-chunkserver from init.d script on boot.
+#   Only allowed values are "true" and "false".
+#   Undefined values default to "false".
+SAUNAFSCHUNKSERVER_ENABLE=false
+
+DAEMON_OPTS=""

--- a/debian/saunafs-chunkserver.init
+++ b/debian/saunafs-chunkserver.init
@@ -1,0 +1,108 @@
+#!/bin/sh
+
+### BEGIN INIT INFO
+# Provides:            saunafs-chunkserver
+# Required-Start:      $network $remote_fs
+# Required-Stop:       $remote_fs
+# Default-Start:       2 3 4 5
+# Default-Stop:        0 1 6
+# Short-Description:   Start saunafs-chunkserver at boot time
+# Description:         saunafs-chunkservers provide storage space for SaunaFS.
+### END INIT INFO
+
+PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
+DAEMON=/usr/sbin/sfschunkserver
+NAME=sfschunkserver
+DESC=saunafs-chunkserver
+DEFAULT_WORKING_USER=saunafs
+DEFAULT_WORKING_GROUP=saunafs
+DEFAULT_DATA_PATH=/var/lib/saunafs
+DEFAULT_CFG=/etc/saunafs/sfschunkserver.cfg
+
+test -e $DAEMON || exit 0
+
+# Include saunafs-chunkserver defaults if available
+. /lib/lsb/init-functions
+SAUNAFSCHUNKSERVER_ENABLE=false
+SAUNAFSCHUNKSERVER_CONFIG_FILE=
+SAUNAFSCHUNKSERVER_DEFAULTS_FILE=/etc/default/saunafs-chunkserver
+
+if [ -s "$SAUNAFSCHUNKSERVER_DEFAULTS_FILE" ]; then
+    . "$SAUNAFSCHUNKSERVER_DEFAULTS_FILE"
+    case "x$SAUNAFSCHUNKSERVER_ENABLE" in
+        xtrue) ;;
+        xfalse)
+            log_warning_msg "saunafs-chunkserver not enabled in \"$SAUNAFSCHUNKSERVER_DEFAULTS_FILE\", exiting..."
+            exit 0
+            ;;
+        *)
+            log_failure_msg "value of SAUNAFSCHUNKSERVER_ENABLE must be either 'true' or 'false';"
+            log_failure_msg "not starting saunafs-chunkserver."
+            exit 1
+            ;;
+    esac
+fi
+
+set -e
+
+if [ -n "$SAUNAFSCHUNKSERVER_CONFIG_FILE" ]; then
+    CFGFILE="$SAUNAFSCHUNKSERVER_CONFIG_FILE"
+else
+    CFGFILE="$DEFAULT_CFG"
+fi
+
+get_config_value_from_CFGFILE()
+{
+    # parsing the value of config options from CFGFILE
+    echo $(sed -e 's/[[:blank:]]*#.*$//' -n -e 's/^[[:blank:]]*'$1'[[:blank:]]*=[[:blank:]]*\(.*\)$/\1/p' $CFGFILE)
+}
+
+if [ -s "$CFGFILE" ]; then
+    DATA_PATH=$(get_config_value_from_CFGFILE "DATA_PATH")
+    WORKING_USER=$(get_config_value_from_CFGFILE "WORKING_USER")
+    WORKING_GROUP=$(get_config_value_from_CFGFILE "WORKING_GROUP")
+
+fi
+
+: ${DATA_PATH:=$DEFAULT_DATA_PATH}
+: ${WORKING_USER:=$DEFAULT_WORKING_USER}
+: ${WORKING_GROUP:=$DEFAULT_WORKING_GROUP}
+
+check_dirs()
+{
+    # check that the metadata dir exists
+    if [ ! -d "$DATA_PATH" ]; then
+        mkdir -p "$DATA_PATH"
+    fi
+    chmod 0755 "$DATA_PATH"
+    chown -R $WORKING_USER:$WORKING_GROUP "$DATA_PATH"
+}
+
+case "$1" in
+    start)
+        check_dirs
+        echo "Starting $DESC:"
+        $DAEMON ${CFGFILE:+-c $CFGFILE} $DAEMON_OPTS start
+        ;;
+    stop)
+        echo "Stopping $DESC:"
+        $DAEMON ${CFGFILE:+-c $CFGFILE} stop
+        ;;
+    reload|force-reload)
+        check_dirs
+        echo "Reloading $DESC:"
+        $DAEMON ${CFGFILE:+-c $CFGFILE} reload
+        ;;
+    restart)
+        check_dirs
+        echo "Restarting $DESC:"
+        $DAEMON ${CFGFILE:+-c $CFGFILE} $DAEMON_OPTS restart
+        ;;
+    *)
+        N=/etc/init.d/$NAME
+        echo "Usage: $N {start|stop|restart|reload|force-reload}" >&2
+        exit 1
+        ;;
+esac
+
+exit 0

--- a/debian/saunafs-chunkserver.service
+++ b/debian/saunafs-chunkserver.service
@@ -5,14 +5,11 @@ After=network-online.target network.target
 
 [Service]
 Type=forking
-User=saunafs
-Group=saunafs
-Environment=CONFIG_FILE=/etc/saunafs/sfschunkserver.cfg
-ExecStart=/usr/sbin/sfschunkserver start -c ${CONFIG_FILE}
+TimeoutSec=0
+ExecStart=/usr/sbin/sfschunkserver start
 ExecStop=/usr/sbin/sfschunkserver stop
 ExecReload=/usr/sbin/sfschunkserver reload
 Restart=on-abort
-TimeoutSec=0
 
 [Install]
 WantedBy=multi-user.target

--- a/debian/saunafs-ha-master.service
+++ b/debian/saunafs-ha-master.service
@@ -5,13 +5,11 @@ PartOf=saunafs-uraft.service
 
 [Service]
 Type=forking
-User=saunafs
-Group=saunafs
+TimeoutSec=0
 ExecStart=/usr/sbin/saunafs-uraft-helper start-saunafs-ha-master
 ExecStop=/usr/sbin/saunafs-uraft-helper stop-saunafs-ha-master
 ExecReload=/usr/sbin/saunafs-uraft-helper reload-saunafs-ha-master
 Restart=no
-TimeoutSec=0
 
 [Install]
 WantedBy=multi-user.target

--- a/debian/saunafs-master.default
+++ b/debian/saunafs-master.default
@@ -1,0 +1,8 @@
+# /etc/default/saunafs-master
+
+# Start saunafs-master from init.d script on boot.
+#   Only allowed values are "true" and "false".
+#   Undefined values default to "false".
+SAUNAFSMASTER_ENABLE=false
+
+DAEMON_OPTS=""

--- a/debian/saunafs-master.init
+++ b/debian/saunafs-master.init
@@ -1,0 +1,108 @@
+#!/bin/sh
+
+### BEGIN INIT INFO
+# Provides:            saunafs-master
+# Required-Start:      $network $remote_fs
+# Required-Stop:       $remote_fs
+# Default-Start:       2 3 4 5
+# Default-Stop:        0 1 6
+# Short-Description:   Start saunafs-master at boot time
+# Description:         saunafs-master provides metadata management for SaunaFS.
+### END INIT INFO
+
+PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
+DAEMON=/usr/sbin/sfsmaster
+NAME=sfsmaster
+DESC=saunafs-master
+DEFAULT_WORKING_USER=saunafs
+DEFAULT_WORKING_GROUP=saunafs
+DEFAULT_DATA_PATH=/var/lib/saunafs
+DEFAULT_CFG=/etc/saunafs/sfsmaster.cfg
+
+test -e $DAEMON || exit 0
+
+# Include saunafs-master defaults if available
+. /lib/lsb/init-functions
+SAUNAFSMASTER_ENABLE=false
+SAUNAFSMASTER_CONFIG_FILE=
+SAUNAFSMASTER_DEFAULTS_FILE=/etc/default/saunafs-master
+if [ -s "$SAUNAFSMASTER_DEFAULTS_FILE" ]; then
+    . "$SAUNAFSMASTER_DEFAULTS_FILE"
+    case "x$SAUNAFSMASTER_ENABLE" in
+        xtrue) ;;
+        xfalse)
+            log_warning_msg "saunafs-master not enabled in \"$SAUNAFSMASTER_DEFAULTS_FILE\", exiting..."
+            exit 0
+            ;;
+        *)
+            log_failure_msg "value of SAUNAFSMASTER_ENABLE must be either 'true' or 'false';"
+            log_failure_msg "not starting saunafs-master."
+            exit 1
+            ;;
+    esac
+fi
+
+set -e
+
+if [ -n "$SAUNAFSMASTER_CONFIG_FILE" ]; then
+    CFGFILE="$SAUNAFSMASTER_CONFIG_FILE"
+else
+    CFGFILE="$DEFAULT_CFG"
+fi
+
+get_config_value_from_CFGFILE()
+{
+    echo $(sed -e 's/[[:blank:]]*#.*$//' -n -e 's/^[[:blank:]]*'$1'[[:blank:]]*=[[:blank:]]*\(.*\)$/\1/p' $CFGFILE)
+}
+
+if [ -s "$CFGFILE" ]; then
+    DATA_PATH=$(get_config_value_from_CFGFILE "DATA_PATH")
+    WORKING_USER=$(get_config_value_from_CFGFILE "WORKING_USER")
+    WORKING_GROUP=$(get_config_value_from_CFGFILE "WORKING_GROUP")
+fi
+
+: ${DATA_PATH:=$DEFAULT_DATA_PATH}
+: ${WORKING_USER:=$DEFAULT_WORKING_USER}
+: ${WORKING_GROUP:=$DEFAULT_WORKING_GROUP}
+
+check_dirs()
+{
+    # check that the metadata dir exists
+    if [ ! -d "$DATA_PATH" ]; then
+        mkdir -p "$DATA_PATH"
+    fi
+    chmod 0755 "$DATA_PATH"
+    chown -R $WORKING_USER:$WORKING_GROUP "$DATA_PATH"
+}
+
+case "$1" in
+    start)
+        check_dirs
+        echo "Starting $DESC:"
+        $DAEMON ${CFGFILE:+-c $CFGFILE} $DAEMON_OPTS start
+        ;;
+
+    stop)
+        echo "Stopping $DESC:"
+        $DAEMON ${CFGFILE:+-c $CFGFILE} stop
+        ;;
+
+    reload|force-reload)
+        echo "Reloading $DESC:"
+        $DAEMON ${CFGFILE:+-c $CFGFILE} reload
+        ;;
+
+    restart)
+        check_dirs
+        echo "Restarting $DESC:"
+        $DAEMON ${CFGFILE:+-c $CFGFILE} restart
+        ;;
+
+    *)
+        N=/etc/init.d/$NAME
+        echo "Usage: $N {start|stop|restart|force-reload}" >&2
+        exit 1
+        ;;
+esac
+
+exit 0

--- a/debian/saunafs-master.service
+++ b/debian/saunafs-master.service
@@ -5,11 +5,8 @@ After=network-online.target network.target
 
 [Service]
 Type=forking
-User=saunafs
-Group=saunafs
-Environment=CONFIG_FILE=/etc/saunafs/sfsmaster.cfg
 TimeoutSec=0
-ExecStart=/usr/sbin/sfsmaster start -c ${CONFIG_FILE}
+ExecStart=/usr/sbin/sfsmaster start
 ExecStop=/usr/sbin/sfsmaster stop
 ExecReload=/usr/sbin/sfsmaster reload
 Restart=no

--- a/debian/saunafs-metalogger.default
+++ b/debian/saunafs-metalogger.default
@@ -1,0 +1,8 @@
+# /etc/default/saunafs-metalogger
+
+# Start saunafs-metalogger from init.d script on boot.
+#   Only allowed values are "true" and "false".
+#   Undefined values default to "false".
+SAUNAFSMETALOGGER_ENABLE=false
+
+DAEMON_OPTS=""

--- a/debian/saunafs-metalogger.init
+++ b/debian/saunafs-metalogger.init
@@ -1,0 +1,106 @@
+#!/bin/sh
+
+### BEGIN INIT INFO
+# Provides:            saunafs-metalogger
+# Required-Start:      $network $remote_fs
+# Required-Stop:       $remote_fs
+# Default-Start:       2 3 4 5
+# Default-Stop:        0 1 6
+# Short-Description:   Start saunafs-metalogger at boot time
+# Description:         saunafs-metaloggers provide metadata replication for SaunaFS.
+### END INIT INFO
+
+PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
+DAEMON=/usr/sbin/sfsmetalogger
+NAME=sfsmetalogger
+DESC=saunafs-metalogger
+DEFAULT_WORKING_USER=saunafs
+DEFAULT_WORKING_GROUP=saunafs
+DEFAULT_DATA_PATH=/var/lib/saunafs
+DEFAULT_CFG=/etc/saunafs/sfsmetalogger.cfg
+
+test -e $DAEMON || exit 0
+
+# Include saunafs-metalogger defaults if available
+. /lib/lsb/init-functions
+SAUNAFSMETALOGGER_ENABLE=false
+SAUNAFSMETALOGGER_CONFIG_FILE=
+SAUNAFSMETALOGGER_DEFAULTS_FILE=/etc/default/saunafs-metalogger
+if [ -s "$SAUNAFSMETALOGGER_DEFAULTS_FILE" ]; then
+    . "$SAUNAFSMETALOGGER_DEFAULTS_FILE"
+    case "x$SAUNAFSMETALOGGER_ENABLE" in
+        xtrue) ;;
+        xfalse)
+            log_warning_msg "saunafs-metalogger not enabled in \"$SAUNAFSMETALOGGER_DEFAULTS_FILE\", exiting..."
+            exit 0
+            ;;
+        *)
+            log_failure_msg "value of SAUNAFSMETALOGGER_ENABLE must be either 'true' or 'false';"
+            log_failure_msg "not starting saunafs-metalogger."
+            exit 1
+            ;;
+    esac
+fi
+
+set -e
+
+if [ -n "$SAUNAFSMETALOGGER_CONFIG_FILE" ]; then
+    CFGFILE="$SAUNAFSMETALOGGER_CONFIG_FILE"
+else
+    CFGFILE="$DEFAULT_CFG"
+fi
+
+get_config_value_from_CFGFILE()
+{
+    # parsing the value of config options from CFGFILE
+    echo $(sed -e 's/[[:blank:]]*#.*$//' -n -e 's/^[[:blank:]]*'$1'[[:blank:]]*=[[:blank:]]*\(.*\)$/\1/p' $CFGFILE)
+}
+
+if [ -s "$CFGFILE" ]; then
+    DATA_PATH=$(get_config_value_from_CFGFILE "DATA_PATH")
+    WORKING_USER=$(get_config_value_from_CFGFILE "WORKING_USER")
+    WORKING_GROUP=$(get_config_value_from_CFGFILE "WORKING_GROUP")
+fi
+: ${DATA_PATH:=$DEFAULT_DATA_PATH}
+: ${WORKING_USER:=$DEFAULT_WORKING_USER}
+: ${WORKING_GROUP:=$DEFAULT_WORKING_GROUP}
+
+check_dirs()
+{
+    # check that the metadata dir exists
+    if [ ! -d "$DATA_PATH" ]; then
+        mkdir -p "$DATA_PATH"
+    fi
+    chmod 0755 "$DATA_PATH"
+    chown -R $WORKING_USER:$WORKING_GROUP "$DATA_PATH"
+}
+
+case "$1" in
+    start)
+        check_dirs
+        echo "Starting $DESC:"
+        $DAEMON ${CFGFILE:+-c $CFGFILE} $DAEMON_OPTS start
+        ;;
+    stop)
+        echo "Stopping $DESC:"
+        $DAEMON ${CFGFILE:+-c $CFGFILE} stop
+        echo "$NAME."
+        ;;
+    reload|force-reload)
+        check_dirs
+        echo "Reloading $DESC:"
+        $DAEMON ${CFGFILE:+-c $CFGFILE} reload
+        ;;
+    restart)
+        check_dirs
+        echo "Restarting $DESC:"
+        $DAEMON ${CFGFILE:+-c $CFGFILE} $DAEMON_OPTS restart
+        ;;
+    *)
+        N=/etc/init.d/$NAME
+        echo "Usage: $N {start|stop|restart|reload|force-reload}" >&2
+        exit 1
+        ;;
+esac
+
+exit 0

--- a/debian/saunafs-metalogger.service
+++ b/debian/saunafs-metalogger.service
@@ -5,8 +5,6 @@ After=network-online.target network.target
 
 [Service]
 Type=forking
-User=saunafs
-Group=saunafs
 ExecStart=/usr/sbin/sfsmetalogger start
 ExecStop=/usr/sbin/sfsmetalogger stop
 ExecReload=/usr/sbin/sfsmetalogger reload

--- a/debian/saunafs-uraft.default
+++ b/debian/saunafs-uraft.default
@@ -1,0 +1,8 @@
+# /etc/default/saunafs-uraft
+
+# Start saunafs-uraft from init.d script on boot.
+#   Only allowed values are "true" and "false".
+#   Undefined values default to "false".
+SAUNAFSURAFT_ENABLE=false
+
+DAEMON_OPTS=""

--- a/debian/saunafs-uraft.init
+++ b/debian/saunafs-uraft.init
@@ -1,0 +1,103 @@
+#!/bin/sh
+#
+### BEGIN INIT INFO
+# Provides:            saunafs-uraft
+# Required-Start:      $local_fs $network $syslog $remote_fs
+# Required-Stop:       $local_fs $syslog $remote_fs
+# Should-Start:        $syslog
+# Should-Stop:         $network $syslog
+# Default-Start:       2 3 4 5
+# Default-Stop:        0 1 6
+# Short-Description:   Start up saunafs-master managed by saunafs-uraft high availability daemon
+# Description:         SaunaFS is a distributed, scalable, fault-tolerant and highly available file system.
+#                      This service starts up SaunaFS master managed by high availability daemon.
+### END INIT INFO
+
+NAME=saunafs-uraft
+DAEMON=/usr/sbin/saunafs-uraft
+MASTER=/usr/sbin/sfsmaster
+MASTER_OPTS="-o ha-cluster-managed -o initial-personality=shadow"
+SAUNAFSURAFT_USER=saunafs
+SAUNAFSURAFT_GROUP=saunafs
+
+# Exit if executable is not installed
+[ -x $DAEMON ] || exit 0
+
+PIDF=/var/run/${NAME}.pid
+RETRY=TERM/30/KILL/5
+
+# Load the VERBOSE setting and other rcS variables
+[ -f /etc/default/rcS ] && . /etc/default/rcS
+
+# define LSB log_* functions.
+. /lib/lsb/init-functions
+
+# Include saunafs-master defaults if available
+SAUNAFSURAFT_ENABLE=false
+SAUNAFSURAFT_CONFIG_FILE=
+SAUNAFSURAFT_DEFAULTS_FILE=/etc/default/saunafs-uraft
+if [ -s "$SAUNAFSURAFT_DEFAULTS_FILE" ] ; then
+    . "$SAUNAFSURAFT_DEFAULTS_FILE"
+    case "x$SAUNAFSURAFT_ENABLE" in
+        xtrue) ;;
+        xfalse)
+           log_warning_msg "saunafs-uraft not enabled in \"$SAUNAFSURAFT_DEFAULTS_FILE\", exiting..."
+           exit 0
+           ;;
+        *)
+            log_failure_msg "value of SAUNAFSURAFT_ENABLE must be either 'true' or 'false';"
+            log_failure_msg "not starting saunafs-uraft."
+            exit 1
+            ;;
+    esac
+fi
+
+case "$1" in
+    start)
+        if $0 status >>/dev/null; then
+            log_action_msg "$NAME is already running"
+            exit 0
+        fi
+        log_action_begin_msg "$NAME starting"
+        R=$($MASTER $MASTER_OPTS start)
+        if ! $R ; then
+            log_action_end_msg 1 "$R"
+        else
+            R=$(start-stop-daemon --start --exec ${DAEMON} --oknodo --pidfile ${PIDF} --make-pidfile \
+                --background --chuid ${SAUNAFSURAFT_USER}:${SAUNAFSURAFT_GROUP} 2>&1)
+            if $R ; then
+                log_action_end_msg 0 "$R"
+            else
+                log_action_end_msg 1 "$R"
+            fi
+        fi
+    ;;
+    stop)
+        log_action_begin_msg "$NAME stopping"
+        R=$($MASTER $MASTER_OPTS stop)
+        if ! $R ; then
+            log_action_end_msg 1 "$R"
+        else
+            R=$(start-stop-daemon --stop --exec ${DAEMON} --pidfile $PIDF --retry=$RETRY --quiet)
+            if $R ; then
+                log_action_end_msg 0 "$R"
+            else
+                log_action_end_msg 1 "not running"
+            fi
+            rm -f "$PIDF"
+        fi
+        /usr/sbin/saunafs-uraft-helper drop-ip
+    ;;
+    force-reload|restart)
+        $0 stop
+        $0 start
+    ;;
+    status)
+        ## return status 0 if process is running.
+        status_of_proc -p "$PIDF" "$DAEMON" "$NAME"
+    ;;
+    *)
+        N=/etc/init.d/$NAME
+        echo "Usage: $N {start|stop|restart|force-reload|status}" >&2
+    ;;
+esac


### PR DESCRIPTION
Recent changes to sysvinit caused the removal of the saunafs-master-ha systemd service. This PR reverts it