### PR TITLE
build: Remove removed man pages

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+saunafs (5.5.0~rc1-2) stable; urgency=medium
+
+  * Drop removed man pages: saunafs-rgetgoal, saunafs-rgettrashtime,
+    saunafs-rsetgoal, saunafs-rsettrashtime.
+
+ -- Saunafs Team <support@saunafs.com>  Wed, 03 Dec 2025 10:34:11 +0200
+
 saunafs (5.5.0~rc1-1) stable; urgency=medium
 
   * Update SaunaFS version

--- a/debian/saunafs-client.manpages
+++ b/debian/saunafs-client.manpages
@@ -9,11 +9,7 @@ usr/share/man/man1/saunafs-getgoal.1
 usr/share/man/man1/saunafs-gettrashtime.1
 usr/share/man/man1/saunafs-makesnapshot.1
 usr/share/man/man1/saunafs-repquota.1
-usr/share/man/man1/saunafs-rgetgoal.1
-usr/share/man/man1/saunafs-rgettrashtime.1
 usr/share/man/man1/saunafs-rremove.1
-usr/share/man/man1/saunafs-rsetgoal.1
-usr/share/man/man1/saunafs-rsettrashtime.1
 usr/share/man/man1/saunafs-seteattr.1
 usr/share/man/man1/saunafs-setgoal.1
 usr/share/man/man1/saunafs-setquota.1


### PR DESCRIPTION
The source code has removed the man files, but the package is still expecting them. This commit removes the requirement of these files.