### PR TITLE
fix(debian): add missing dependency for saunafs-cgiserv

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+saunafs (5.8.0~rc2-2) stable; urgency=medium
+
+  * Add missing dependency for saunafs-cgiserv (python3-chardet)
+
+ -- Saunafs Team <support@saunafs.com>  Thu, 12 Mar 2026 13:26:04 +0100
+
 saunafs (5.8.0~rc2-1) stable; urgency=medium
 
   * Update SaunaFS version

--- a/debian/control
+++ b/debian/control
@@ -124,7 +124,8 @@ Description: SaunaFS CGI Monitor
 Package: saunafs-cgiserv
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}, saunafs-cgi,
-         python3
+         python3,
+         python3-chardet
 Description: Simple CGI-capable HTTP server to run SaunaFS CGI Monitor
  Simple CGI-capable HTTP server to run SaunaFS CGI Monitor.
 


### PR DESCRIPTION
This commit adds the python3-chardet dependency required by
saunafs-cgiserv. This dependency was introduced in a SaunaFS fix
but was not added to the Debian packaging. As a result, the cgiserv
service fails to run correctly.

Signed-off-by: Crash <crash@leil.io>