### PR TITLE
chore: delete UPGRADE file references

### DIFF
--- a/debian/docs
+++ b/debian/docs
@@ -1,3 +1,2 @@
 NEWS
 README.md
-UPGRADE


### PR DESCRIPTION
The references to this UPGRADE file were deleted on the target leilfs repo as it is not used as main file for  migration steps during upgrades of LeilFS, then this file references should also be deleted here.