### PR TITLE
chore: update binary names to LeilFS rebrand

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -1,7 +1,7 @@
 Source: saunafs
 Section: admin
 Priority: extra
-Maintainer: SaunaFS <support@leil.io>
+Maintainer: LeilFS <support@leil.io>
 Build-Depends: debhelper (>= 9),
 # Probably half the packages are not needed, but we need a thorough review of
 # this
@@ -58,15 +58,15 @@ Package: saunafs-dbg
 Architecture: any
 Section: debug
 Depends: ${shlibs:Depends}, ${misc:Depends}
-Description: Debugging symbols for SaunaFS
- Debugging symbols for all SaunaFS binaries
+Description: Debugging symbols for LeilFS
+ Debugging symbols for all LeilFS binaries
 
 Package: saunafs-common
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends},
          adduser
-Description: SaunaFS common files
- Files and services common for all SaunaFS daemons.
+Description: LeilFS common files
+ Files and services common for all LeilFS daemons.
  .
  This package also offers helper scripts to manage
  migrations between major versions and other utilities.
@@ -75,59 +75,59 @@ Description: SaunaFS common files
 Package: saunafs-master
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}, saunafs-common
-Description: SaunaFS master server
- SaunaFS master (metadata) server.
+Description: LeilFS master server
+ LeilFS master (metadata) server.
 
 Package: saunafs-metalogger
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}, saunafs-common
-Description: SaunaFS metalogger server
- SaunaFS metalogger (metadata replication) server.
+Description: LeilFS metalogger server
+ LeilFS metalogger (metadata replication) server.
 
 Package: saunafs-chunkserver
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}, saunafs-common
-Description: SaunaFS data server
- SaunaFS data server.
+Description: LeilFS data server
+ LeilFS data server.
 
 Package: saunafs-client
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}, bash-completion
-Description: SaunaFS client
- SaunaFS clients: sfsmount and sfstools.
+Description: LeilFS client
+ LeilFS clients: leil-mount and leil tools.
 
 Package: saunafs-lib-client
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}
-Description: SaunaFS client C/C++ library
- SaunaFS client library for C/C++ bindings.
+Description: LeilFS client C/C++ library
+ LeilFS client library for C/C++ bindings.
 
 Package: saunafs-nfs-ganesha
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}, saunafs-lib-client
-Description: SaunaFS plugin for nfs-ganesha
- SaunaFS fsal plugin for nfs-ganesha.
+Description: LeilFS plugin for nfs-ganesha
+ LeilFS fsal plugin for nfs-ganesha.
 
 Package: saunafs-adm
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}
-Description: SaunaFS administration tools
- SaunaFS administration tools: saunafs-admin
+Description: LeilFS administration tools
+ LeilFS administration tools: leil-admin
 
 Package: saunafs-cgi
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends},
          python3
-Description: SaunaFS CGI Monitor
- SaunaFS CGI Monitor.
+Description: LeilFS CGI Monitor
+ LeilFS CGI Monitor.
 
 Package: saunafs-cgiserv
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}, saunafs-cgi,
          python3,
          python3-chardet
-Description: Simple CGI-capable HTTP server to run SaunaFS CGI Monitor
- Simple CGI-capable HTTP server to run SaunaFS CGI Monitor.
+Description: Simple CGI-capable HTTP server to run LeilFS CGI Monitor
+ Simple CGI-capable HTTP server to run LeilFS CGI Monitor.
 
 Package: saunafs-uraft
 Architecture: any
@@ -136,8 +136,8 @@ Depends: saunafs-master,
          iputils-arping,
          sudo,
          ${shlibs:Depends},
-Description: SaunaFS cluster management tool
- SaunaFS is a distributed filesystem.
+Description: LeilFS cluster management tool
+ LeilFS is a distributed filesystem.
  .
- This package offers means for simplified SaunaFS deployment
+ This package offers means for simplified LeilFS deployment
  on cluster infrastructure.

--- a/debian/saunafs-adm.install
+++ b/debian/saunafs-adm.install
@@ -1,2 +1,2 @@
-usr/bin/saunafs-admin
-usr/bin/saunafs-probe
+usr/bin/leil-admin
+usr/bin/leil-probe

--- a/debian/saunafs-cgi.install
+++ b/debian/saunafs-cgi.install
@@ -1,1 +1,1 @@
-usr/share/sfscgi
+usr/share/leil-cgi

--- a/debian/saunafs-cgiserv.default
+++ b/debian/saunafs-cgiserv.default
@@ -16,5 +16,5 @@
 ## port to listen on (default: 9425)
 # BIND_PORT=9425
 
-## local path to use as HTTP document root (default: /usr/share/sfscgi)
-# ROOT_PATH=/usr/share/sfscgi
+## local path to use as HTTP document root (default: /usr/share/leil-cgi)
+# ROOT_PATH=/usr/share/leil-cgi

--- a/debian/saunafs-cgiserv.init
+++ b/debian/saunafs-cgiserv.init
@@ -9,18 +9,18 @@
 # Default-Start:       2 3 4 5
 # Default-Stop:        0 1 6
 # Short-Description:   Start up the saunafs-cgiserv server daemon
-# Description:         SaunaFS is a distributed, scalable, fault-tolerant and highly available file system.
-#                      This service starts up the SaunaFS cgiserv server daemon.
+# Description:         LeilFS is a distributed, scalable, fault-tolerant and highly available file system.
+#                      This service starts up the LeilFS cgiserv server daemon.
 ### END INIT INFO
 
 NAME=saunafs-cgiserv
 EXEC=/usr/bin/python3
-DAEMON=/usr/sbin/saunafs-cgiserver
+DAEMON=/usr/sbin/leil-cgiserver
 SAUNAFSCGISERV_USER=saunafs
 SAUNAFSCGISERV_GROUP=saunafs
 BIND_HOST=0.0.0.0
 BIND_PORT=9425
-ROOT_PATH=/usr/share/sfscgi
+ROOT_PATH=/usr/share/leil-cgi
 
 # Exit if executable is not installed
 [ -x $DAEMON ] || exit 0

--- a/debian/saunafs-cgiserv.install
+++ b/debian/saunafs-cgiserv.install
@@ -1,1 +1,1 @@
-usr/sbin/saunafs-cgiserver
+usr/sbin/leil-cgiserver

--- a/debian/saunafs-cgiserv.service
+++ b/debian/saunafs-cgiserv.service
@@ -1,14 +1,14 @@
 [Unit]
-Description=SaunaFS CGI server daemon
+Description=LeilFS CGI server daemon
 Documentation=man:saunafs-cgiserver
 After=network-online.target network.target
 
 [Service]
 Environment=BIND_HOST=0.0.0.0
 Environment=BIND_PORT=9425
-Environment=ROOT_PATH=/usr/share/sfscgi
+Environment=ROOT_PATH=/usr/share/leil-cgi
 EnvironmentFile=-/etc/default/%p
-ExecStart=/usr/sbin/saunafs-cgiserver -H ${BIND_HOST} -P ${BIND_PORT} -R ${ROOT_PATH}
+ExecStart=/usr/sbin/leil-cgiserver -H ${BIND_HOST} -P ${BIND_PORT} -R ${ROOT_PATH}
 Restart=on-abort
 User=saunafs
 

--- a/debian/saunafs-chunkserver.init
+++ b/debian/saunafs-chunkserver.init
@@ -7,11 +7,11 @@
 # Default-Start:       2 3 4 5
 # Default-Stop:        0 1 6
 # Short-Description:   Start saunafs-chunkserver at boot time
-# Description:         saunafs-chunkservers provide storage space for SaunaFS.
+# Description:         saunafs-chunkservers provide storage space for LeilFS.
 ### END INIT INFO
 
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
-DAEMON=/usr/sbin/sfschunkserver
+DAEMON=/usr/sbin/leil-chunkserver
 NAME=sfschunkserver
 DESC=saunafs-chunkserver
 DEFAULT_WORKING_USER=saunafs

--- a/debian/saunafs-chunkserver.install
+++ b/debian/saunafs-chunkserver.install
@@ -1,1 +1,1 @@
-usr/sbin/sfschunkserver
+usr/sbin/leil-chunkserver

--- a/debian/saunafs-chunkserver.service
+++ b/debian/saunafs-chunkserver.service
@@ -1,14 +1,14 @@
 [Unit]
-Description=SaunaFS chunkserver daemon
+Description=LeilFS chunkserver daemon
 Documentation=man:sfschunkserver
 After=network-online.target network.target
 
 [Service]
 Type=forking
 TimeoutSec=0
-ExecStart=/usr/sbin/sfschunkserver start
-ExecStop=/usr/sbin/sfschunkserver stop
-ExecReload=/usr/sbin/sfschunkserver reload
+ExecStart=/usr/sbin/leil-chunkserver start
+ExecStop=/usr/sbin/leil-chunkserver stop
+ExecReload=/usr/sbin/leil-chunkserver reload
 Restart=on-abort
 
 [Install]

--- a/debian/saunafs-client.install
+++ b/debian/saunafs-client.install
@@ -1,3 +1,3 @@
 etc/bash_completion.d/saunafs
-usr/bin/saunafs
-usr/bin/sfsmount
+usr/bin/leil
+usr/bin/leil-mount

--- a/debian/saunafs-client.links
+++ b/debian/saunafs-client.links
@@ -1,1 +1,1 @@
-/usr/bin/sfsmount /sbin/mount.safs
+/usr/bin/leil-mount /sbin/mount.safs

--- a/debian/saunafs-ha-master.service
+++ b/debian/saunafs-ha-master.service
@@ -1,14 +1,14 @@
 [Unit]
-Description=SaunaFS master server daemon
+Description=LeilFS master server daemon
 After=syslog.target network-online.target network.target
 PartOf=saunafs-uraft.service
 
 [Service]
 Type=forking
 TimeoutSec=0
-ExecStart=/usr/sbin/saunafs-uraft-helper start-saunafs-ha-master
-ExecStop=/usr/sbin/saunafs-uraft-helper stop-saunafs-ha-master
-ExecReload=/usr/sbin/saunafs-uraft-helper reload-saunafs-ha-master
+ExecStart=/usr/sbin/leil-uraft-helper start-saunafs-ha-master
+ExecStop=/usr/sbin/leil-uraft-helper stop-saunafs-ha-master
+ExecReload=/usr/sbin/leil-uraft-helper reload-saunafs-ha-master
 Restart=no
 
 [Install]

--- a/debian/saunafs-master.init
+++ b/debian/saunafs-master.init
@@ -7,11 +7,11 @@
 # Default-Start:       2 3 4 5
 # Default-Stop:        0 1 6
 # Short-Description:   Start saunafs-master at boot time
-# Description:         saunafs-master provides metadata management for SaunaFS.
+# Description:         saunafs-master provides metadata management for LeilFS.
 ### END INIT INFO
 
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
-DAEMON=/usr/sbin/sfsmaster
+DAEMON=/usr/sbin/leil-master
 NAME=sfsmaster
 DESC=saunafs-master
 DEFAULT_WORKING_USER=saunafs

--- a/debian/saunafs-master.install
+++ b/debian/saunafs-master.install
@@ -1,5 +1,5 @@
-usr/sbin/sfsmaster
-usr/sbin/sfsmetadump
-usr/sbin/sfsmetarestore
-usr/sbin/sfsrestoremaster
+usr/sbin/leil-master
+usr/sbin/leil-metadump
+usr/sbin/leil-metarestore
+usr/sbin/leil-restoremaster
 var/lib/saunafs/metadata.sfs.empty

--- a/debian/saunafs-master.service
+++ b/debian/saunafs-master.service
@@ -1,14 +1,14 @@
 [Unit]
-Description=SaunaFS master server daemon
+Description=LeilFS master server daemon
 Documentation=man:sfsmaster
 After=network-online.target network.target
 
 [Service]
 Type=forking
 TimeoutSec=0
-ExecStart=/usr/sbin/sfsmaster start
-ExecStop=/usr/sbin/sfsmaster stop
-ExecReload=/usr/sbin/sfsmaster reload
+ExecStart=/usr/sbin/leil-master start
+ExecStop=/usr/sbin/leil-master stop
+ExecReload=/usr/sbin/leil-master reload
 Restart=no
 
 [Install]

--- a/debian/saunafs-metalogger.init
+++ b/debian/saunafs-metalogger.init
@@ -7,11 +7,11 @@
 # Default-Start:       2 3 4 5
 # Default-Stop:        0 1 6
 # Short-Description:   Start saunafs-metalogger at boot time
-# Description:         saunafs-metaloggers provide metadata replication for SaunaFS.
+# Description:         saunafs-metaloggers provide metadata replication for LeilFS.
 ### END INIT INFO
 
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
-DAEMON=/usr/sbin/sfsmetalogger
+DAEMON=/usr/sbin/leil-metalogger
 NAME=sfsmetalogger
 DESC=saunafs-metalogger
 DEFAULT_WORKING_USER=saunafs

--- a/debian/saunafs-metalogger.install
+++ b/debian/saunafs-metalogger.install
@@ -1,1 +1,1 @@
-usr/sbin/sfsmetalogger
+usr/sbin/leil-metalogger

--- a/debian/saunafs-metalogger.service
+++ b/debian/saunafs-metalogger.service
@@ -1,13 +1,13 @@
 [Unit]
-Description=SaunaFS metalogger server daemon
+Description=LeilFS metalogger server daemon
 Documentation=man:sfsmetalogger
 After=network-online.target network.target
 
 [Service]
 Type=forking
-ExecStart=/usr/sbin/sfsmetalogger start
-ExecStop=/usr/sbin/sfsmetalogger stop
-ExecReload=/usr/sbin/sfsmetalogger reload
+ExecStart=/usr/sbin/leil-metalogger start
+ExecStop=/usr/sbin/leil-metalogger stop
+ExecReload=/usr/sbin/leil-metalogger reload
 Restart=on-abort
 
 [Install]

--- a/debian/saunafs-uraft.init
+++ b/debian/saunafs-uraft.init
@@ -9,13 +9,13 @@
 # Default-Start:       2 3 4 5
 # Default-Stop:        0 1 6
 # Short-Description:   Start up saunafs-master managed by saunafs-uraft high availability daemon
-# Description:         SaunaFS is a distributed, scalable, fault-tolerant and highly available file system.
-#                      This service starts up SaunaFS master managed by high availability daemon.
+# Description:         LeilFS is a distributed, scalable, fault-tolerant and highly available file system.
+#                      This service starts up LeilFS master managed by high availability daemon.
 ### END INIT INFO
 
 NAME=saunafs-uraft
-DAEMON=/usr/sbin/saunafs-uraft
-MASTER=/usr/sbin/sfsmaster
+DAEMON=/usr/sbin/leil-uraft
+MASTER=/usr/sbin/leil-master
 MASTER_OPTS="-o ha-cluster-managed -o initial-personality=shadow"
 SAUNAFSURAFT_USER=saunafs
 SAUNAFSURAFT_GROUP=saunafs
@@ -86,7 +86,7 @@ case "$1" in
             fi
             rm -f "$PIDF"
         fi
-        /usr/sbin/saunafs-uraft-helper drop-ip
+        /usr/sbin/leil-uraft-helper drop-ip
     ;;
     force-reload|restart)
         $0 stop

--- a/debian/saunafs-uraft.install
+++ b/debian/saunafs-uraft.install
@@ -1,2 +1,2 @@
-usr/sbin/saunafs-uraft
-usr/sbin/saunafs-uraft-helper
+usr/sbin/leil-uraft
+usr/sbin/leil-uraft-helper

--- a/debian/saunafs-uraft.service
+++ b/debian/saunafs-uraft.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=SaunaFS uraft high availability daemon
+Description=LeilFS uraft high availability daemon
 Requires=saunafs-ha-master.service
 After=network-online.target network.target
 After=saunafs-ha-master.service
@@ -8,8 +8,8 @@ After=saunafs-ha-master.service
 Type=simple
 PIDFile=/var/run/saunafs-uraft.pid
 TimeoutSec=0
-ExecStart=/usr/sbin/saunafs-uraft
-ExecStopPost=/usr/sbin/saunafs-uraft-helper drop-ip
+ExecStart=/usr/sbin/leil-uraft
+ExecStopPost=/usr/sbin/leil-uraft-helper drop-ip
 Restart=on-failure
 RestartSec=60
 User=saunafs


### PR DESCRIPTION
This commit ensures that Debian packages are built using the binaries with rebranded name corresponding to LeilFS.

Related to: LS-676