### PR TITLE
chore: add symlinks refs to old saunafs bins

### DIFF
--- a/debian/saunafs-adm.install
+++ b/debian/saunafs-adm.install
@@ -1,2 +1,4 @@
 usr/bin/leil-admin
 usr/bin/leil-probe
+usr/bin/saunafs-admin
+usr/bin/saunafs-probe

--- a/debian/saunafs-cgi.install
+++ b/debian/saunafs-cgi.install
@@ -1,1 +1,2 @@
 usr/share/leil-cgi
+usr/share/sfscgi

--- a/debian/saunafs-cgiserv.install
+++ b/debian/saunafs-cgiserv.install
@@ -1,1 +1,2 @@
 usr/sbin/leil-cgiserver
+usr/sbin/saunafs-cgiserver

--- a/debian/saunafs-chunkserver.install
+++ b/debian/saunafs-chunkserver.install
@@ -1,1 +1,2 @@
 usr/sbin/leil-chunkserver
+usr/sbin/sfschunkserver

--- a/debian/saunafs-client.install
+++ b/debian/saunafs-client.install
@@ -1,3 +1,5 @@
 etc/bash_completion.d/saunafs
 usr/bin/leil
+usr/bin/saunafs
 usr/bin/leil-mount
+usr/bin/sfsmount

--- a/debian/saunafs-master.install
+++ b/debian/saunafs-master.install
@@ -1,5 +1,9 @@
 usr/sbin/leil-master
+usr/sbin/sfsmaster
 usr/sbin/leil-metadump
+usr/sbin/sfsmetadump
 usr/sbin/leil-metarestore
+usr/sbin/sfsmetarestore
 usr/sbin/leil-restoremaster
+usr/sbin/sfsrestoremaster
 var/lib/saunafs/metadata.sfs.empty

--- a/debian/saunafs-metalogger.install
+++ b/debian/saunafs-metalogger.install
@@ -1,1 +1,2 @@
 usr/sbin/leil-metalogger
+usr/sbin/sfsmetalogger

--- a/debian/saunafs-uraft.install
+++ b/debian/saunafs-uraft.install
@@ -1,2 +1,4 @@
 usr/sbin/leil-uraft
+usr/sbin/saunafs-uraft
 usr/sbin/leil-uraft-helper
+usr/sbin/saunafs-uraft-helper


### PR DESCRIPTION
Install compatibility symlinks from the legacy saunafs-* executable names to their corresponding leil-* binaries.

The executable renaming introduced as part of the LeilFS rebranding is an external interface change that may affect customer automation, monitoring integrations, operational tooling, deployment scripts, and other third-party components that invoke the previous executable names.

Keeping compatibility symlinks during the 5.x release series allows existing deployments to continue functioning while giving users time to migrate to the new leil-* naming convention.

These compatibility symlinks are intended as a transitional mechanism and may be removed in a future major release.

Depends on: https://github.com/leil-io/leilfs/pull/884
Related to: LS-830